### PR TITLE
Fix: minimumPowerUpSizeBabz should consider power and burn pools

### DIFF
--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -37,7 +37,7 @@ contract PowerEnabled is MarketEnabled {
   }
 
   function minimumPowerUpSizeBabz() public constant returns (uint256) {
-    return totalSupply().div(MIN_SHARE_OF_POWER);
+    return completeSupply().div(MIN_SHARE_OF_POWER);
   }
 
   // this is called when NTZ are deposited into the burn pool
@@ -129,7 +129,7 @@ contract PowerEnabled is MarketEnabled {
 
   function createDownRequest(address _owner, uint256 _amountPower) public onlyPower whenNotPaused {
     // prevent powering down tiny amounts
-    // when powering down, at least totalSupply/minShare Power should be claimed
+    // when powering down, at least completeSupply/minShare Power should be claimed
     require(_amountPower >= authorizedPower().div(MIN_SHARE_OF_POWER));
     _setPowerBalanceOf(_owner, powerBalanceOf(_owner).sub(_amountPower));
 

--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -37,7 +37,11 @@ contract PowerEnabled is MarketEnabled {
   }
 
   function minimumPowerUpSizeBabz() public constant returns (uint256) {
-    return completeSupply().div(MIN_SHARE_OF_POWER);
+    uint256 completeSupplyBabz = completeSupply();
+    if (completeSupplyBabz == 0) {
+      return INFINITY;
+    }
+    return completeSupplyBabz.div(MIN_SHARE_OF_POWER);
   }
 
   // this is called when NTZ are deposited into the burn pool

--- a/test/power.js
+++ b/test/power.js
@@ -202,26 +202,35 @@ contract('Power', (accounts) => {
     assert(downs[2].toNumber() > 0, "Power down start timestamp");
   });
 
-  it('minimumPowerUpSizeBabz() should return size of 1/100000 of the economy', async() => {
-    await controller.moveFloor(INFINITY);
-    await controller.moveCeiling(30000);
-    const power = Power.at(await controller.powerAddr.call());
+  describe('#minimumPowerUpSizeBabz', () => {
 
-    // get some NTZ for 1 ETH
-    await nutz.purchase(30000, {from: accounts[0], value: WEI_AMOUNT });
+    it('should return INFINITY when there is no NTZ in supply', async() => {
+      // no power possible when no ntz in supply, expect min share to be Infinity
+      assert.equal((await controller.minimumPowerUpSizeBabz()).toNumber(), INFINITY, "Initial share size");
+    });
 
-    // at this point we have 30000 ntz in supply and we expect min share ntz size to be 1/100000 of that
-    let minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
-    assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+    it('should return size of 1/100000 of the economy', async() => {
+      // get some NTZ for 1 ETH
+      await controller.moveFloor(INFINITY);
+      await controller.moveCeiling(30000);
+      await nutz.purchase(30000, {from: accounts[0], value: WEI_AMOUNT });
 
-    // power up half of NTZ
-    await controller.dilutePower(0, 0);
-    const authorizedPower = await power.totalSupply.call();
-    await controller.setMaxPower(authorizedPower);
-    await nutz.powerUp(babz(15000).toNumber());
+      // at this point we have 30000 ntz in supply and we expect min share ntz size to be 1/100000 of that
+      let minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
+      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
 
-    // we expect min share ntz size to stay unchanged, cause it includes power pool
-    assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+      // power up half of NTZ
+      await controller.dilutePower(0, 0);
+      const power = Power.at(await controller.powerAddr.call());
+      const authorizedPower = await power.totalSupply.call();
+      await controller.setMaxPower(authorizedPower);
+      await nutz.powerUp(babz(15000).toNumber());
+
+      // we expect min share ntz size to stay unchanged, cause it includes power pool
+      minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
+      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+    });
+
   });
 
 });

--- a/test/power.js
+++ b/test/power.js
@@ -202,4 +202,26 @@ contract('Power', (accounts) => {
     assert(downs[2].toNumber() > 0, "Power down start timestamp");
   });
 
+  it('minimumPowerUpSizeBabz() should return size of 1/100000 of the economy', async() => {
+    await controller.moveFloor(INFINITY);
+    await controller.moveCeiling(30000);
+    const power = Power.at(await controller.powerAddr.call());
+
+    // get some NTZ for 1 ETH
+    await nutz.purchase(30000, {from: accounts[0], value: WEI_AMOUNT });
+
+    // at this point we have 30000 ntz in supply and we expect min share ntz size to be 1/100000 of that
+    let minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
+    assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+
+    // power up half of NTZ
+    await controller.dilutePower(0, 0);
+    const authorizedPower = await power.totalSupply.call();
+    await controller.setMaxPower(authorizedPower);
+    await nutz.powerUp(babz(15000).toNumber());
+
+    // we expect min share ntz size to stay unchanged, cause it includes power pool
+    assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+  });
+
 });


### PR DESCRIPTION
- use `completeSupply` for `minimumPowerUpSizeBabz`
- make `minimumPowerUpSizeBabz` to return Infinity when no NTZ supply. Formerly it was returning 0 which doesn't make sense