### PR TITLE
Feature:compact upgrade event

### DIFF
--- a/contracts/policies/PowerEventReplacement.sol
+++ b/contracts/policies/PowerEventReplacement.sol
@@ -30,4 +30,30 @@ contract PowerEventReplacement is PowerEvent {
     state = EventState.Collecting;
   }
 
+  function completeClosed() isState(EventState.Closed) {
+    var contr = Controller(controllerAddr);
+    // move ceiling
+    uint256 ceiling = contr.ceiling();
+    uint256 newCeiling = ceiling.mul(RATE_FACTOR).div(1500000);
+    contr.moveCeiling(newCeiling);
+    // dilute power
+    uint256 totalSupply = contr.completeSupply();
+    uint256 newSupply = totalSupply.sub(initialSupply);
+    contr.dilutePower(newSupply, amountPower);
+    // set max power
+    var PowerContract = ERC20(powerAddr);
+    uint256 authorizedPower = PowerContract.totalSupply();
+    contr.setMaxPower(authorizedPower);
+    // pay out milestone
+    uint256 collected = nutzAddr.balance.sub(initialReserve);
+    for (uint256 i = 0; i < milestoneRecipients.length; i++) {
+      uint256 payoutAmount = collected.mul(milestoneShares[i]).div(RATE_FACTOR);
+      contr.allocateEther(payoutAmount, milestoneRecipients[i]);
+    }
+    // remove access
+    contr.removeAdmin(address(this));
+    // set state
+    state = EventState.Complete;
+  }
+
 }

--- a/contracts/policies/PowerEventReplacement.sol
+++ b/contracts/policies/PowerEventReplacement.sol
@@ -22,10 +22,6 @@ contract PowerEventReplacement is PowerEvent {
     nutzAddr = contr.nutzAddr();
     initialSupply = 2399896170149257466012; //initialSupply as per old Power Event
     initialReserve = 22469750000000000000;  // initialReserve as per old Power Event
-    uint256 ceiling = contr.ceiling();
-    // move ceiling
-    uint256 newCeiling = ceiling.mul(discountRate).div(RATE_FACTOR);
-    contr.moveCeiling(newCeiling);
     // set state
     state = EventState.Collecting;
   }

--- a/contracts/policies/UpgradeEventCompact.sol
+++ b/contracts/policies/UpgradeEventCompact.sol
@@ -41,15 +41,7 @@ contract UpgradeEventCompact {
     _;
   }
 
-  function tick() public {
-    if (state == EventState.Verifying) {
-      verifyComplete();
-    } else {
-      throw;
-    }
-  }
-
-  function verifyComplete() isState(EventState.Verifying) {
+  function upgrade() isState(EventState.Verifying) {
     // check old controller
     var old = Controller(oldController);
     old.pause();

--- a/contracts/policies/UpgradeEventCompact.sol
+++ b/contracts/policies/UpgradeEventCompact.sol
@@ -1,0 +1,96 @@
+pragma solidity ^0.4.11;
+
+import '../controller/Controller.sol';
+import '../ownership/Ownable.sol';
+
+contract UpgradeEventCompact {
+
+  // states
+  //  - verifying, initial state
+  //  - controlling, after verifying, before complete
+  //  - complete, after controlling
+  enum EventState { Verifying, Complete }
+  EventState public state;
+
+  // Terms
+  address public nextController;
+  address public oldController;
+  address public council;
+
+  // Params
+  address powerEventReplacement;
+  address nextPullPayment;
+  address storageAddr;
+  address nutzAddr;
+  address powerAddr;
+  uint256 maxPower;
+  uint256 downtime;
+  uint256 purchasePrice;
+  uint256 salePrice;
+
+  function UpgradeEventCompact(address _oldController, address _nextController, address _nextPullPayment) {
+    state = EventState.Verifying;
+    nextController = _nextController;
+    oldController = _oldController;
+    nextPullPayment = _nextPullPayment; //the ownership of this satellite should be with oldController
+    council = msg.sender;
+  }
+
+  modifier isState(EventState _state) {
+    require(state == _state);
+    _;
+  }
+
+  function tick() public {
+    if (state == EventState.Verifying) {
+      verifyComplete();
+    } else {
+      throw;
+    }
+  }
+
+  function verifyComplete() isState(EventState.Verifying) {
+    // check old controller
+    var old = Controller(oldController);
+    old.pause();
+    require(old.admins(1) == address(this));
+    require(old.paused() == true);
+    // check next controller
+    var next = Controller(nextController);
+    require(next.admins(1) == address(this));
+    require(next.paused() == true);
+    // kill old one, and transfer ownership
+    // transfer ownership of payments and storage to here
+    storageAddr = old.storageAddr();
+    nutzAddr = old.nutzAddr();
+    powerAddr = old.powerAddr();
+    maxPower = old.maxPower();
+    downtime = old.downtime();
+    purchasePrice = old.ceiling();
+    salePrice = old.floor();
+    //set pull payment contract in old controller
+    old.setContracts(powerAddr, nextPullPayment, nutzAddr, storageAddr);
+    // kill old controller, sending all ETH to new controller
+    old.kill(nextController);
+    // transfer ownership of Nutz/Power contracts to next controller
+    Ownable(nutzAddr).transferOwnership(nextController);
+    Ownable(powerAddr).transferOwnership(nextController);
+    // transfer ownership of storage to next controller
+    Ownable(storageAddr).transferOwnership(nextController);
+    // if intended, transfer ownership of pull payment account
+    Ownable(nextPullPayment).transferOwnership(nextController);
+    // resume next controller
+    if (maxPower > 0) {
+      next.setMaxPower(maxPower);
+    }
+    next.setDowntime(downtime);
+    next.moveFloor(salePrice);
+    next.moveCeiling(purchasePrice);
+    next.unpause();
+    // remove access
+    next.removeAdmin(address(this));
+    // set state
+    state = EventState.Complete;
+  }
+
+}

--- a/test/upgradeEvent.js
+++ b/test/upgradeEvent.js
@@ -111,6 +111,7 @@ contract('UpgradeEvent', (accounts) => {
     const discountRate2 = 1500000; // 150% -> make ceiling 30,000
     const milestoneRecipients2 = [EXEC_BOARD, GOVERNING_COUNCIL];
     const milestoneShares2 = [200000, 5000]; // 20% and 0.5%
+    const ceilingBeforeEvent2 = await nutz.ceiling.call();
     const event2 = await PowerEvent.new(controller.address, startTime, minDuration, maxDuration, softCap2, hardCap2, discountRate2, 0, milestoneRecipients2, milestoneShares2);
     // event #2 - buy in
     await controller.addAdmin(event2.address);
@@ -177,9 +178,11 @@ contract('UpgradeEvent', (accounts) => {
     assert.equal(amountAllocated.toNumber(), WEI_AMOUNT * 6000, 'ether wasn\'t allocated to beneficiary');
 
     // check power allocation proper after controller upgrade and replacement Event
+    const ceilingAftereEvent2 = await nutz.ceiling.call();
     const totalPow = await power.totalSupply.call();
     const founderPow = await power.balanceOf.call(FOUNDERS);
     const investorsPow = await power.balanceOf.call(INVESTORS);
+    assert.equal(ceilingBeforeEvent2.toNumber(), ceilingAftereEvent2.toNumber());
     assert.equal(founderPow.toNumber(), totalPow.mul(0.7).toNumber());
     assert.equal(investorsPow.toNumber(), totalPow.mul(0.3).toNumber());
     assert.equal(totalPow.toNumber(), POW_DECIMALS.mul(900000).toNumber());

--- a/test/upgradeEvent.js
+++ b/test/upgradeEvent.js
@@ -263,8 +263,8 @@ contract('UpgradeEvent', (accounts) => {
     await nextController.addAdmin(upgradeEventComppact.address);
     await controller.addAdmin(upgradeEventComppact.address);
 
-    // ATOMIC TICK
-    await upgradeEventComppact.tick();
+    // ATOMIC upgrade
+    await upgradeEventComppact.upgrade();
 
     const pullAddrSet = await nextController.pullAddr();
     assert.equal(pullAddrSet, pullNew.address, 'New Pull Payment wasn\'t set in nextcontroller');

--- a/test/upgradeEvent.js
+++ b/test/upgradeEvent.js
@@ -6,6 +6,7 @@ const MockController = artifacts.require('./helpers/MockController.sol');
 const PowerEvent = artifacts.require('./policies/PowerEvent.sol');
 const PowerEventReplacement = artifacts.require('./helpers/MockPowerEventReplacement.sol');
 const UpgradeEvent = artifacts.require('./policies/UpgradeEvent.sol');
+const UpgradeEventCompact = artifacts.require('./policies/UpgradeEventCompact.sol');
 const BigNumber = require('bignumber.js');
 const NTZ_DECIMALS = new BigNumber(10).pow(12);
 const POW_DECIMALS = new BigNumber(10).pow(12);
@@ -187,6 +188,131 @@ contract('UpgradeEvent', (accounts) => {
     assert.equal(investorsPow.toNumber(), totalPow.mul(0.3).toNumber());
     assert.equal(totalPow.toNumber(), POW_DECIMALS.mul(900000).toNumber());
   });
+
+  it('should allow compact upgrade to controller in one ATOMIC tick()', async () => {
+
+    // set ceiling and floor before Power Event
+    const CEILING_PRICE = 20000;
+    await controller.moveFloor(INFINITY);
+    await controller.moveCeiling(CEILING_PRICE);
+
+    // prepare event #1
+    const FOUNDERS = accounts[1];
+    const startTime = (Date.now() / 1000 | 0) - 60;
+    const minDuration = 0;
+    const maxDuration = 3600;
+    const softCap = WEI_AMOUNT;
+    const hardCap = WEI_AMOUNT;
+    const discountRate = 60000000000; // make ceiling 1,200,000,000
+    const amountPower = POW_DECIMALS.mul(630000).mul(2);
+    const milestoneRecipients = [];
+    const milestoneShares = [];
+    const event1 = await PowerEvent.new(controller.address, startTime, minDuration, maxDuration, softCap, hardCap, discountRate, amountPower, milestoneRecipients, milestoneShares);
+    await controller.addAdmin(event1.address);
+    await event1.tick();
+    // event #1 - buyin
+    await nutz.purchase(1200000000, {from: FOUNDERS, value: WEI_AMOUNT });
+    // event #1 - burn
+    await event1.tick();
+    await event1.tick();
+    // event #1 power up
+    await nutz.powerUp(babz(1200000), { from: FOUNDERS });
+    const totalPow1 = await power.totalSupply.call();
+    const founderPow1 = await power.balanceOf.call(FOUNDERS);
+    assert.equal(founderPow1.toNumber(), totalPow1.toNumber());
+    assert.equal(totalPow1.toNumber(), POW_DECIMALS.mul(630000).toNumber());
+
+    // prepare event #2
+    const INVESTORS = accounts[2];
+    const EXEC_BOARD = accounts[3];
+    const GOVERNING_COUNCIL = accounts[4];
+    const ceiling = new BigNumber(30000);
+    const MIN_NTZ = new BigNumber(30);
+    const softCap2 = WEI_AMOUNT * 5000;
+    const hardCap2 = WEI_AMOUNT * 30000;
+    const etherBalance = WEI_AMOUNT * 99;
+    const smallSwapEther = WEI_AMOUNT * 1;
+    const discountRate2 = 1500000; // 150% -> make ceiling 30,000
+    const milestoneRecipients2 = [EXEC_BOARD, GOVERNING_COUNCIL];
+    const milestoneShares2 = [200000, 5000]; // 20% and 0.5%
+    const ceilingBeforeEvent2 = await nutz.ceiling.call();
+    const event2 = await PowerEvent.new(controller.address, startTime, minDuration, maxDuration, softCap2, hardCap2, discountRate2, 0, milestoneRecipients2, milestoneShares2);
+    // event #2 - buy in
+    await controller.addAdmin(event2.address);
+    await event2.startCollection();
+    await nutz.purchase(30000, {from: INVESTORS, value: etherBalance });
+
+    // purchase some tokens with ether
+    await nutz.purchase(30000, {from: accounts[0], value: smallSwapEther });
+
+    const nutzBalanceBefore = await web3.eth.getBalance(nutz.address);
+    // check balance, supply and reserve
+    const babzBalBefore = await nutz.balanceOf.call(accounts[0]);
+    assert.equal(babzBalBefore.toNumber(), MIN_NTZ.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
+
+    // #START OF THE UPGRADE PROCESS
+
+    // deploy new pull payment contract
+    const pullNew = await PullPayment.new();
+    await pullNew.transferOwnership(controller.address);
+    // remove old Power Event
+    await controller.removeAdmin(event2.address);
+    // upgrade controller contract (next controller with new pull payment address)
+    const nextController = await MockController.new(power.address, pullNew.address, nutz.address, storage.address);
+    const upgradeEventComppact = await UpgradeEventCompact.new(controller.address, nextController.address, pullNew.address);
+    await nextController.addAdmin(upgradeEventComppact.address);
+    await controller.addAdmin(upgradeEventComppact.address);
+
+    // ATOMIC TICK
+    await upgradeEventComppact.tick();
+
+    const pullAddrSet = await nextController.pullAddr();
+    assert.equal(pullAddrSet, pullNew.address, 'New Pull Payment wasn\'t set in nextcontroller');
+    // check balance with next controller
+    const babzBalAfter = await nutz.balanceOf.call(accounts[0]);
+    assert.equal(babzBalAfter.toNumber(), MIN_NTZ.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
+    // check eth migrated
+    const reserveWei = web3.eth.getBalance(nutz.address);
+    assert.equal(reserveWei.toNumber(), nutzBalanceBefore, 'ether wasn\'t sent to contract');
+    // check transfers with next controller
+    await nutz.transfer(INVESTORS, babzBalAfter);
+    const babzBalEnd = await nutz.balanceOf.call(accounts[0]);
+    assert.equal(babzBalEnd.toNumber(), 0, 'transfer failed after upgrade');
+
+    // prepare replacement event
+    const discountRate3 = 1000000; // 100% -> keeping ceiling at 30,000
+    const remainingBalance = WEI_AMOUNT * 29900;
+
+    // deploy replacement event
+    const eventReplacement = await PowerEventReplacement.new(nextController.address, startTime, minDuration, maxDuration, softCap2, hardCap2, discountRate3, 0, milestoneRecipients2, milestoneShares2);
+
+    // event #replacement - buy in remaining
+    await nextController.addAdmin(eventReplacement.address);
+
+    await eventReplacement.startCollection();
+    await nutz.purchase(30000, {from: INVESTORS, value: remainingBalance });
+    // event #replacement - burn
+    await eventReplacement.stopCollection();
+    await eventReplacement.completeClosed();
+    // event #replacement - power up
+    const investorsBal = await nutz.balanceOf.call(INVESTORS);
+    await nutz.powerUp(investorsBal, { from: INVESTORS });
+    // event #replacement - milestone payment
+    await controller.moveFloor(CEILING_PRICE * 2);
+    let amountAllocated = await pullNew.balanceOf.call(EXEC_BOARD);
+    assert.equal(amountAllocated.toNumber(), WEI_AMOUNT * 6000, 'ether wasn\'t allocated to beneficiary');
+
+    // check power allocation proper after controller upgrade and replacement Event
+    const ceilingAftereEvent2 = await nutz.ceiling.call();
+    const totalPow = await power.totalSupply.call();
+    const founderPow = await power.balanceOf.call(FOUNDERS);
+    const investorsPow = await power.balanceOf.call(INVESTORS);
+    assert.equal(ceilingBeforeEvent2.toNumber(), ceilingAftereEvent2.toNumber());
+    assert.equal(founderPow.toNumber(), totalPow.mul(0.7).toNumber());
+    assert.equal(investorsPow.toNumber(), totalPow.mul(0.3).toNumber());
+    assert.equal(totalPow.toNumber(), POW_DECIMALS.mul(900000).toNumber());
+  });
+
 
   it('should allow to recover from emergency');
 


### PR DESCRIPTION
Upgrade event compact now has only one `tick()`. `verify()` and `complete()` squashed to `verifyComplete()`. The one tick contains -

- **Pausing** old controller

- Setting the new pull Payment contract in old controller

- Killing old controller

- Transferring ownership of all satellites

- Setting old ceiling, floor and downtime to new controller.

- **Unpausing** next controller
