### PR TITLE
WIP: replace min power up restriction of 1/100000 share with flat 100 NTZ

### DIFF
--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -15,7 +15,7 @@ contract PowerEnabled is MarketEnabled {
   // time it should take to power down
   uint256 public downtime;
 
-  uint public constant MIN_SHARE_OF_POWER = 100000;
+//  uint public constant MIN_SHARE_OF_POWER = 100000;
 
   modifier onlyPower() {
     require(msg.sender == powerAddr);
@@ -41,7 +41,7 @@ contract PowerEnabled is MarketEnabled {
     if (completeSupplyBabz == 0) {
       return INFINITY;
     }
-    return completeSupplyBabz.div(MIN_SHARE_OF_POWER);
+    return 100000000000000; // 100 NTZ
   }
 
   // this is called when NTZ are deposited into the burn pool
@@ -93,7 +93,7 @@ contract PowerEnabled is MarketEnabled {
     uint256 outstandingPow = outstandingPower();
     require(outstandingPow.add(amountPow) <= maxPower);
     uint256 powBal = powerBalanceOf(_from).add(amountPow);
-    require(powBal >= authorizedPow.div(MIN_SHARE_OF_POWER));
+    //require(powBal >= authorizedPow.div(MIN_SHARE_OF_POWER));
 
     if (_sender != _from) {
       allowed[_from][_sender] = allowed[_from][_sender].sub(_amountBabz);
@@ -134,7 +134,7 @@ contract PowerEnabled is MarketEnabled {
   function createDownRequest(address _owner, uint256 _amountPower) public onlyPower whenNotPaused {
     // prevent powering down tiny amounts
     // when powering down, at least completeSupply/minShare Power should be claimed
-    require(_amountPower >= authorizedPower().div(MIN_SHARE_OF_POWER));
+    //require(_amountPower >= authorizedPower().div(MIN_SHARE_OF_POWER));
     _setPowerBalanceOf(_owner, powerBalanceOf(_owner).sub(_amountPower));
 
     var (, left, ) = downs(_owner);

--- a/test/helpers/economy.js
+++ b/test/helpers/economy.js
@@ -1,13 +1,12 @@
 const fromCents = function fromCents(cents) {
-  return cents.div(Math.pow(10, 12));
+  let val = cents.div(Math.pow(10, 12));
+  return val.toFixed(12);
 }
 
 const printValue = function printValue(cents, ticker) {
   const l = fromCents(cents).toString().length;
-  let tabs = `\t\t\t`;
-  if (l > 13) tabs = '\t\t';
-  if (l >= 19) tabs = '\t';
-  if (l < 4) tabs = '\t\t\t\t';
+  let tabs = `\t\t`;
+  if (l > 14) tabs = '\t';
   return `${fromCents(cents)} ${ticker}${tabs} ${cents}`;
 }
 
@@ -25,7 +24,6 @@ const printEconomy = async function(controller, nutz, power, user) {
     console.log(`User Babz:\t\t ${printValue(await nutz.balanceOf.call(user), 'NTZ')}`);
     let userPower = await power.balanceOf.call(user);
     console.log(`User Power:\t\t ${printValue(userPower, 'ABP')}`);
-    console.log(`Babz for power down?:\t ${printValue(userPower.mul(await controller.completeSupply.call()).div(await controller.authorizedPower.call()), 'NTZ')}`)
   }
   console.log(`---`);
 }

--- a/test/helpers/economy.js
+++ b/test/helpers/economy.js
@@ -1,0 +1,35 @@
+const fromCents = function fromCents(cents) {
+  return cents.div(Math.pow(10, 12));
+}
+
+const printValue = function printValue(cents, ticker) {
+  const l = fromCents(cents).toString().length;
+  let tabs = `\t\t\t`;
+  if (l > 13) tabs = '\t\t';
+  if (l >= 19) tabs = '\t';
+  if (l < 4) tabs = '\t\t\t\t';
+  return `${fromCents(cents)} ${ticker}${tabs} ${cents}`;
+}
+
+const printEconomy = async function(controller, nutz, power, user) {
+  console.log(`---`);
+  console.log(`Complete supply babz:\t ${printValue(await controller.completeSupply.call(), 'NTZ')}`);
+  console.log(`Active supply babz:\t ${printValue(await controller.activeSupply.call(), 'NTZ')}`);
+  console.log(`Total power:\t\t ${printValue(await power.totalSupply.call(), 'ABP')}`);
+  console.log(`Authorized power:\t ${printValue(await controller.authorizedPower.call(), 'ABP')}`);
+  console.log(`Outstanding power:\t ${printValue(await controller.outstandingPower.call(), 'ABP')}`);
+  console.log(`Power pool:\t\t ${printValue(await controller.powerPool.call(), 'NTZ')}`);
+  console.log(`Burn pool:\t\t ${printValue(await controller.burnPool.call(), 'NTZ')}`);
+
+  if (user) {
+    console.log(`User Babz:\t\t ${printValue(await nutz.balanceOf.call(user), 'NTZ')}`);
+    let userPower = await power.balanceOf.call(user);
+    console.log(`User Power:\t\t ${printValue(userPower, 'ABP')}`);
+    console.log(`Babz for power down?:\t ${printValue(userPower.mul(await controller.completeSupply.call()).div(await controller.authorizedPower.call()), 'NTZ')}`)
+  }
+  console.log(`---`);
+}
+
+module.exports = {
+  printValue, printEconomy, fromCents
+}

--- a/test/power.js
+++ b/test/power.js
@@ -174,8 +174,9 @@ contract('Power', (accounts) => {
     const powerUpVal = babz(100000);
     await nutz.powerUp(powerUpVal);
 
-    // keep power pool size to use it for later calculations
+    // keep power pool size & active supply size to use it for later calculations
     const oldPowerPool = await controller.powerPool.call();
+    const activeSupply = await controller.activeSupply.call();
 
     // but some more NTZ. We expect power pool to increase more
     await controller.moveCeiling(20000);
@@ -183,7 +184,6 @@ contract('Power', (accounts) => {
 
     // let's check power pool increased precisely
     const newPowerPool = await controller.powerPool.call();
-    const activeSupply = await controller.activeSupply.call();
     const burnPool = await controller.burnPool.call();
     // replicating power pool increase logic from purchase() method
     const expectedPool = oldPowerPool.add(oldPowerPool.mul(new BigNumber(20000).mul(WEI_AMOUNT).div(1000000)).div(activeSupply.add(burnPool)));

--- a/test/power.js
+++ b/test/power.js
@@ -314,7 +314,7 @@ contract('Power', (accounts) => {
       assert.equal((await controller.minimumPowerUpSizeBabz()).toNumber(), INFINITY, "Initial share size");
     });
 
-    it('should return size of 1/100000 of the economy', async() => {
+    it('should be 100 NTZ', async() => {
       // get some NTZ for 1 ETH
       await controller.moveFloor(INFINITY);
       await controller.moveCeiling(30000);
@@ -322,7 +322,7 @@ contract('Power', (accounts) => {
 
       // at this point we have 30000 ntz in supply and we expect min share ntz size to be 1/100000 of that
       let minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
-      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+      assert.equal(minShareSizeBabz, babz(100).toNumber(), "Min share size");
 
       // power up half of NTZ
       await controller.dilutePower(0, 0);
@@ -333,7 +333,7 @@ contract('Power', (accounts) => {
 
       // we expect min share ntz size to stay unchanged, cause it includes power pool
       minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
-      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
+      assert.equal(minShareSizeBabz, babz(100).toNumber(), "Min share size");
     });
 
   });


### PR DESCRIPTION
I can't reproduce any rounding problems — see unit test. Things go bad when powering up hundreds of babz, which doesn't make sense. I hardcoded 100 NTZ as a minimum which is purely arbitrary.

@bkcninja @johannbarbie can you point me to the possible situation with rounding problems?


Also here rounding issue with power pool: in a certain conditions it grows by extra 7 babz on purchase
