### PR TITLE
Min babz set to flat 1000 NTZ

### DIFF
--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -82,6 +82,7 @@ contract PowerEnabled is MarketEnabled {
     uint256 amountPow = _amountBabz.mul(authorizedPow).div(totalBabz);
     // check pow limits
     uint256 outstandingPow = outstandingPower();
+    require(outstandingPow.add(amountPow) <= maxPower);
     uint256 powBal = powerBalanceOf(_from).add(amountPow);
 
     if (_sender != _from) {

--- a/test/nutz.js
+++ b/test/nutz.js
@@ -183,7 +183,7 @@ contract('Nutz', (accounts) => {
     await controller.moveCeiling(ceiling);
 
 
-    await nutz.purchase(ceiling, {from: accounts[0], value: ONE_ETH });
+    await nutz.purchase(ceiling, {from: accounts[0], value: 2 * ONE_ETH });
 
     // initiate power pool
     await controller.dilutePower(0, 0);
@@ -212,7 +212,7 @@ contract('Nutz', (accounts) => {
       await controller.moveFloor(INFINITY);
       await controller.moveCeiling(ceiling);
 
-      await nutz.purchase(ceiling, {from: accounts[0], value: ONE_ETH });
+      await nutz.purchase(ceiling, {from: accounts[0], value: 2 * ONE_ETH });
 
       // initiate power pool
       await controller.dilutePower(0, 0);

--- a/test/power.js
+++ b/test/power.js
@@ -181,6 +181,27 @@ contract('Power', (accounts) => {
     assert.equal(outstandingBefore.div(outstandingAfter).toNumber(), powerPoolBefore.div(powerPoolAfter).toNumber());
   });
 
+  it("should allow to power up for 1000 nutz without rounding error", async () => {
+    await controller.moveFloor(INFINITY);
+    await controller.moveCeiling(CEILING_PRICE);
+    const power = Power.at(await controller.powerAddr.call());
+
+    // get some NTZ for 1 ETH
+    await nutz.purchase(CEILING_PRICE, {from: accounts[0], value: 2 * 1e18 });
+    await controller.dilutePower(0, 0);
+    const authorizedPower = await power.totalSupply.call();
+    await controller.setMaxPower(authorizedPower);
+
+    const nutzToPowerUp = new BigNumber(10000e12);
+    const authorizedPow = await controller.authorizedPower.call();
+    const totalSupply = await controller.completeSupply.call();
+    const powerCalculated = authorizedPow.div(totalSupply).mul(nutzToPowerUp);
+    await nutz.powerUp(nutzToPowerUp);
+    const outstandingBefore = await power.activeSupply.call();
+    const bal = await power.balanceOf.call(accounts[0]);
+    assert.equal(bal.toNumber(), powerCalculated.toNumber(), '3rd party powerup failed');
+  });
+
   it('#downs should return power down requests in array form', async() => {
     await controller.moveFloor(INFINITY);
     await controller.moveCeiling(CEILING_PRICE);
@@ -200,37 +221,6 @@ contract('Power', (accounts) => {
     assert.equal(downs[0].toNumber(), babz(15000).toNumber(), "Total amount");
     assert.equal(downs[1].toNumber(), babz(15000).toNumber(), "Left amount");
     assert(downs[2].toNumber() > 0, "Power down start timestamp");
-  });
-
-  describe('#minimumPowerUpSizeBabz', () => {
-
-    it('should return INFINITY when there is no NTZ in supply', async() => {
-      // no power possible when no ntz in supply, expect min share to be Infinity
-      assert.equal((await controller.minimumPowerUpSizeBabz()).toNumber(), INFINITY, "Initial share size");
-    });
-
-    it('should return size of 1/100000 of the economy', async() => {
-      // get some NTZ for 1 ETH
-      await controller.moveFloor(INFINITY);
-      await controller.moveCeiling(30000);
-      await nutz.purchase(30000, {from: accounts[0], value: WEI_AMOUNT });
-
-      // at this point we have 30000 ntz in supply and we expect min share ntz size to be 1/100000 of that
-      let minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
-      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
-
-      // power up half of NTZ
-      await controller.dilutePower(0, 0);
-      const power = Power.at(await controller.powerAddr.call());
-      const authorizedPower = await power.totalSupply.call();
-      await controller.setMaxPower(authorizedPower);
-      await nutz.powerUp(babz(15000).toNumber());
-
-      // we expect min share ntz size to stay unchanged, cause it includes power pool
-      minShareSizeBabz = (await controller.minimumPowerUpSizeBabz()).toNumber();
-      assert.equal(minShareSizeBabz, babz(30000).div(100000).toNumber(), "Min share size");
-    });
-
   });
 
 });


### PR DESCRIPTION
Resolves #70
- Saw no rounding errors even at lowest denomination of nutz (10 ^ -12).
- Still set min nutz to a flat 1000
- This nutz value comes to around 15 USD right now.
- Calculated value using reference of (value of nutz transacted >= gas cost) came out to be 200 nutz. 
But in future we dont to keep changing the value based on Nutz cost and gas Price, so a safe value of 1000 nutz.



