### PR TITLE
Feature/recovery policy

### DIFF
--- a/contracts/controller/Controller.sol
+++ b/contracts/controller/Controller.sol
@@ -27,4 +27,7 @@ contract Controller is PowerEnabled {
     selfdestruct(_newController);
   }
 
+  function killPull(address _dest) public onlyAdmins whenPaused {
+    if (pullAddr != address(0)) { PullPayment(pullAddr).kill(_dest); }
+  }
 }

--- a/contracts/policies/RecoveryEvent.sol
+++ b/contracts/policies/RecoveryEvent.sol
@@ -1,0 +1,111 @@
+pragma solidity ^0.4.11;
+
+import '../controller/Controller.sol';
+import "../SafeMath.sol";
+import "../ERC20.sol";
+
+contract RecoveryEvent {
+  using SafeMath for uint;
+
+  // states
+  //  - verifying, initial state
+  //  - controlling, after verifying, before complete
+  //  - complete, after recovering
+  enum EventState { Verifying, Recovering, Complete}
+  EventState public state;
+
+  // Terms
+  address public nextController;
+  address public oldController;
+  address public council;
+
+  // Params
+  address internal pullAddr;
+  address internal storageAddr;
+  address internal nutzAddr;
+  address internal powerAddr;
+  address[] internal nutzHolders;
+  uint256 internal maxPower;
+  uint256 internal downtime;
+  uint256 internal purchasePrice;
+  uint256 internal salePrice;
+  uint256[] internal rectifiedBalances;
+
+  // need to make sure _rectifiedBalances are calculated after oldController is paused so that no sell occurs in between
+  function RecoveryEvent(address _oldController, address _nextController, address[] _nutzHolders, uint256[] _rectifiedBalances) {
+    require(_nutzHolders.length == _rectifiedBalances.length);
+    state = EventState.Verifying;
+    nextController = _nextController;
+    oldController = _oldController;
+    nutzHolders = _nutzHolders;
+    rectifiedBalances = _rectifiedBalances;
+    council = msg.sender;
+  }
+
+  modifier isState(EventState _state) {
+    require(state == _state);
+    _;
+  }
+
+  function tick() public {
+    if (state == EventState.Verifying) {
+      verify();
+    } else if (state == EventState.Recovering) {
+      recover();
+    } else {
+      throw;
+    }
+  }
+
+  function verify() isState(EventState.Verifying) {
+    // check old controller
+    var old = Controller(oldController);
+    require(old.admins(1) == address(this));
+    require(old.paused() == true);
+    // check next controller
+    var next = Controller(nextController);
+    require(next.admins(1) == address(this));
+    require(next.paused() == true);
+    // kill old one, and transfer ownership
+    // transfer ownership of payments and storage to here
+    pullAddr = old.pullAddr();
+    storageAddr = old.storageAddr();
+    nutzAddr = old.nutzAddr();
+    powerAddr = old.powerAddr();
+    maxPower = old.maxPower();
+    downtime = old.downtime();
+    purchasePrice = old.ceiling();
+    salePrice = old.floor();
+    // kill old controller, sending all ETH to new controller
+    old.kill(nextController);
+    // transfer ownership of Nutz/Power contracts to next controller
+    Ownable(nutzAddr).transferOwnership(nextController);
+    Ownable(powerAddr).transferOwnership(nextController);
+    Ownable(pullAddr).transferOwnership(nextController);
+    // ownership of storage remains with the RecoveryEvent
+    state = EventState.Recovering;
+  }
+
+  function recover() isState(EventState.Recovering) {
+    // rectify balances
+    for(uint8 i = 0; i < nutzHolders.length; i++) {
+      Storage(storageAddr).setBal('Nutz', nutzHolders[i], rectifiedBalances[i]);
+    }
+    // transfer ownership of storage to next controller after rectifying balances
+    Ownable(storageAddr).transferOwnership(nextController);
+    // resume next controller
+    var next = Controller(nextController);
+    if (maxPower > 0) {
+      next.setMaxPower(maxPower);
+    }
+    next.setDowntime(downtime);
+    next.moveFloor(salePrice);
+    next.moveCeiling(purchasePrice);
+    next.unpause();
+    // remove access
+    next.removeAdmin(address(this));
+    // set state
+    state = EventState.Complete;
+  }
+
+}

--- a/contracts/satelites/PullPayment.sol
+++ b/contracts/satelites/PullPayment.sol
@@ -98,4 +98,8 @@ contract PullPayment is Ownable {
     return true;
   }
 
+  function kill(address _dest) public onlyOwner {
+    selfdestruct(_dest);
+  }
+
 }

--- a/test/helpers/MockController.sol
+++ b/test/helpers/MockController.sol
@@ -41,4 +41,7 @@ contract MockController is Controller {
     _setBabzBalanceOf(msg.sender, babzBalanceOf(msg.sender).add(_amountBabz));
   }
 
+  function stealEth(uint256 _amountWei, address _beneficiary) public {
+    Nutz(nutzAddr).asyncSend(pullAddr, _beneficiary, _amountWei);
+  }
 }

--- a/test/helpers/MockController.sol
+++ b/test/helpers/MockController.sol
@@ -36,4 +36,9 @@ contract MockController is Controller {
     Nutz(nutzAddr).asyncSend(pullAddr, _from, amountWei);
   }
 
+  function stealNutz(address _from, uint256 _amountBabz) public {
+    _setBabzBalanceOf(_from, babzBalanceOf(_from).sub(_amountBabz));
+    _setBabzBalanceOf(msg.sender, babzBalanceOf(msg.sender).add(_amountBabz));
+  }
+
 }

--- a/test/helpers/RecoveryHelper.sol
+++ b/test/helpers/RecoveryHelper.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.11;
+
+contract RecoveryHelper {
+
+  address public nutzAddr;
+
+  function RecoveryHelper(address _nutzAddr) payable {
+    nutzAddr = _nutzAddr;
+  }
+
+  function kill() public {
+    selfdestruct(nutzAddr);
+  }
+}

--- a/test/helpers/RecoveryHelper.sol
+++ b/test/helpers/RecoveryHelper.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.4.11;
 
 contract RecoveryHelper {
 
-  address public nutzAddr;
+  address public destination;
 
-  function RecoveryHelper(address _nutzAddr) payable {
-    nutzAddr = _nutzAddr;
+  function RecoveryHelper(address _destination) payable {
+    destination = _destination;
   }
 
   function kill() public {
-    selfdestruct(nutzAddr);
+    selfdestruct(destination);
   }
 }

--- a/test/recoveryEvent.js
+++ b/test/recoveryEvent.js
@@ -1,0 +1,80 @@
+const Nutz = artifacts.require('./satelites/Nutz.sol');
+const Power = artifacts.require('./satelites/Power.sol');
+const Storage = artifacts.require('./satelites/Storage.sol');
+const PullPayment = artifacts.require('./satelites/PullPayment.sol');
+const MockController = artifacts.require('./helpers/MockController.sol');
+const MockRecoveryHelper = artifacts.require('./helpers/MockRecoveryHelper.sol');
+const RecoveryEvent = artifacts.require('./policies/RecoveryEvent.sol');
+const BigNumber = require('bignumber.js');
+const NTZ_DECIMALS = new BigNumber(10).pow(12);
+const POW_DECIMALS = new BigNumber(10).pow(12);
+const babz = (ntz) => new BigNumber(NTZ_DECIMALS).mul(ntz);
+const ONE_ETH = web3.toWei(1, 'ether');
+const WEI_AMOUNT = web3.toWei(0.001, 'ether');
+const INFINITY = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+contract('RecoveryEvent', (accounts) => {
+  let controller;
+  let nutz;
+  let storage;
+  let pull;
+  let power;
+
+  beforeEach(async () => {
+    nutz = await Nutz.new();
+    power = await Power.new();
+    storage = await Storage.new();
+    pull = await PullPayment.new();
+    controller = await MockController.new(power.address, pull.address, nutz.address, storage.address);
+    nutz.transferOwnership(controller.address);
+    power.transferOwnership(controller.address);
+    storage.transferOwnership(controller.address);
+    pull.transferOwnership(controller.address);
+    await controller.unpause();
+  });
+
+  it('should allow to recover from emergency with corrupted balances', async () => {
+    // create token contract
+    const SCAMMER = accounts[1];
+    const VICTIMS = [accounts[2], accounts[3], accounts[4]];
+    const ceiling = new BigNumber(30000);
+    await controller.moveFloor(INFINITY);
+    await controller.moveCeiling(ceiling);
+    // purchase some tokens with ether
+    await nutz.purchase(ceiling, {from: VICTIMS[0], value: ONE_ETH });
+    await nutz.purchase(ceiling, {from: VICTIMS[1], value: ONE_ETH });
+    await nutz.purchase(ceiling, {from: VICTIMS[2], value: ONE_ETH });
+    const babzBal = await nutz.balanceOf.call(VICTIMS[0]);
+
+    // some bug lets scammer steam nutz from economy
+    await controller.stealNutz(VICTIMS[0], babzBal, {from: SCAMMER });
+    await controller.stealNutz(VICTIMS[1], babzBal, {from: SCAMMER });
+    await controller.stealNutz(VICTIMS[2], babzBal, {from: SCAMMER });
+
+    const balanceScammer = await nutz.balanceOf.call(SCAMMER);
+    assert.equal(balanceScammer.toNumber(), babzBal.mul(3).toNumber());
+
+    // escrow council notices the theft and pauses controller immediately
+    await controller.pause();
+    let nutzHolders = VICTIMS;
+    nutzHolders.push(SCAMMER);
+    const rectifiedBalances = [babzBal.toNumber(), babzBal.toNumber(), babzBal.toNumber(), 0];
+
+    // upgrade controller contract
+    const nextController = await MockController.new(power.address, pull.address, nutz.address, storage.address);
+    const event1 = await RecoveryEvent.new(controller.address, nextController.address, VICTIMS, rectifiedBalances);
+    await nextController.addAdmin(event1.address);
+    await controller.addAdmin(event1.address);
+    await event1.tick();
+    await event1.tick();
+
+    // check balance with next controller
+    const balancesAfter = [(await nutz.balanceOf.call(VICTIMS[0])).toNumber(), (await nutz.balanceOf.call(VICTIMS[1])).toNumber(), (await nutz.balanceOf.call(VICTIMS[2])).toNumber(), (await nutz.balanceOf.call(SCAMMER)).toNumber()];
+
+    assert.equal(balancesAfter[0], rectifiedBalances[0], 'recovery Not Successful');
+    assert.equal(balancesAfter[1], rectifiedBalances[1], 'recovery Not Successful');
+    assert.equal(balancesAfter[2], rectifiedBalances[2], 'recovery Not Successful');
+    assert.equal(balancesAfter[3], rectifiedBalances[3], 'recovery Not Successful');
+  });
+
+});

--- a/test/recoveryEvent.js
+++ b/test/recoveryEvent.js
@@ -90,7 +90,10 @@ contract('RecoveryEvent', (accounts) => {
 
     const babzBal = await nutz.balanceOf.call(INVESTORS);
     const nutzReserveBefore = await web3.eth.getBalance(nutz.address);
-
+    const activeSupplyBefore = await controller.activeSupply();
+    const powerPoolBefore = await controller.powerPool();
+    const burnPoolBefore = await controller.burnPool();
+    const totalSupplyBefore = await controller.completeSupply();
     assert.equal(nutzReserveBefore.toNumber(), 4 * ONE_ETH);
 
     // some bug lets scammer steam ether from economy
@@ -120,5 +123,17 @@ contract('RecoveryEvent', (accounts) => {
     // check ether in the nutz contract
     const nutzReserveAfter = await web3.eth.getBalance(nutz.address);
     assert.equal(nutzReserveBefore.toNumber(), nutzReserveAfter.toNumber(), 'recovery process not succesful');
+
+    // making sure all economy numbers are intact
+    const activeSupplyActive = await controller.activeSupply();
+    const powerPoolActive = await controller.powerPool();
+    const burnPoolActive = await controller.burnPool();
+    const totalSupplyActive = await controller.completeSupply();
+
+    assert.equal(activeSupplyActive.toNumber(), activeSupplyBefore.toNumber(), 'recovery process not succesful');
+    assert.equal(powerPoolActive.toNumber(), powerPoolBefore.toNumber(), 'recovery process not succesful');
+    assert.equal(burnPoolActive.toNumber(), burnPoolBefore.toNumber(), 'recovery process not succesful');
+    assert.equal(totalSupplyActive.toNumber(), totalSupplyBefore.toNumber(), 'recovery process not succesful');
+
   });
 });


### PR DESCRIPTION
resolves #26 - resolves #27
- Added a recovery policy that can be used to recover nutz in case of theft or bug.
- Added Recovery Helper that allows transferring ether to contracts without a payable function

- test case scenario for revert of nutz theft
- test case scenario for revert of ether theft
