### PR TITLE
change asserts

### DIFF
--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -7,26 +7,29 @@ pragma solidity ^0.4.11;
  */
 library SafeMath {
   function mul(uint256 a, uint256 b) internal returns (uint256) {
+    require(a >= 0 && b >= 0)
     uint256 c = a * b;
-    assert(a == 0 || c / a == b);
+    require(a == 0 || c / a == b);
     return c;
   }
 
   function div(uint256 a, uint256 b) internal returns (uint256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    require(b > 0); // Solidity automatically throws when dividing by 0
+    require(a == b * c + a % b); // There is no case in which this doesn't hold
     uint256 c = a / b;
-    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
   function sub(uint256 a, uint256 b) internal returns (uint256) {
-    assert(b <= a);
+    require(a >= 0 && b >= 0)
+    require(b <= a);
     return a - b;
   }
 
   function add(uint256 a, uint256 b) internal returns (uint256) {
+    require(a >= 0 && b >= 0)
+    require(c >= a)
     uint256 c = a + b;
-    assert(c >= a);
     return c;
   }
 }

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.4.11;
  */
 library SafeMath {
   function mul(uint256 a, uint256 b) internal returns (uint256) {
-    require(a >= 0 && b >= 0)
+    require(a >= 0 && b >= 0);
     uint256 c = a * b;
     require(a == 0 || c / a == b);
     return c;
@@ -21,14 +21,14 @@ library SafeMath {
   }
 
   function sub(uint256 a, uint256 b) internal returns (uint256) {
-    require(a >= 0 && b >= 0)
+    require(a >= 0 && b >= 0);
     require(b <= a);
     return a - b;
   }
 
   function add(uint256 a, uint256 b) internal returns (uint256) {
-    require(a >= 0 && b >= 0)
-    require(c >= a)
+    require(a >= 0 && b >= 0);
+    require(c >= a);
     uint256 c = a + b;
     return c;
   }


### PR DESCRIPTION
asserts are mainly used for testing but in practice, they swallow up all the gas used for the transaction if it evaluates to false. You don't really want to use when you're validating user input for contract functions. It's much safer to use require as it refunds gas to user should sufficient conditions not be met.